### PR TITLE
fix: Use siteLanguage on articles' inLanguage

### DIFF
--- a/src/components/SEO/SEO.jsx
+++ b/src/components/SEO/SEO.jsx
@@ -115,7 +115,7 @@ const SEO = ({ title, desc, banner, pathname, article, node }) => {
       dateModified: node.last_publication_date,
       description: seo.description,
       headline: seo.title,
-      inLanguage: 'en',
+      inLanguage: siteLanguage,
       url: seo.url,
       name: seo.title,
       image: {


### PR DESCRIPTION
Hi! :wave: 

I think we should use the configured language to the articles' `inLanguage` configuration as well.

What do you think?

Cheers and thanks for this repo, I learned a lot about SEO with it!